### PR TITLE
luci-mod-system: add "KiB" to translatable strings

### DIFF
--- a/modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua
+++ b/modules/luci-mod-system/luasrc/model/cbi/admin_system/system.lua
@@ -67,7 +67,7 @@ end
 -- Logging
 --
 
-o = s:taboption("logging", Value, "log_size", translate("System log buffer size"), "kiB")
+o = s:taboption("logging", Value, "log_size", translate("System log buffer size"), translate("KiB"))
 o.optional    = true
 o.placeholder = 16
 o.datatype    = "uinteger"


### PR DESCRIPTION
Also changed original "kiB" to "KiB" in accordance with IEEE 1541-2002.

Signed-off-by: Anton Kikin <a.kikin@tano-systems.com>